### PR TITLE
Add dark mode with theme toggle and dark design tokens

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import HabitForm from '@/components/habits/HabitForm';
 import HabitCard from '@/components/habits/HabitCard';
 import DashboardSkeleton from '@/components/dashboard/DashboardSkeleton';
 import EmptyState from '@/components/dashboard/EmptyState';
+import ThemeToggle from '@/components/shared/ThemeToggle';
 
 export default function DashboardPage() {
   const [session, setSession] = useState<Session | null>(null);
@@ -69,7 +70,8 @@ export default function DashboardPage() {
           <h1 className="font-display text-2xl md:text-3xl font-bold text-foreground">Dashboard</h1>
           <p className="text-secondary-text text-sm md:text-base">Welcome back, {session?.email}</p>
         </div>
-        <div className="flex gap-2 md:gap-4">
+        <div className="flex gap-2 md:gap-4 items-center">
+          <ThemeToggle />
           <button
             onClick={() => setShowForm(true)}
             data-testid="create-habit-button"

--- a/app/globals.css
+++ b/app/globals.css
@@ -157,36 +157,41 @@
   --default-transition-timing-function: var(--ds-ease-default);
 }
 
-/* Force light mode until dark mode lands in a future PR */
-:root {
-  color-scheme: light !important;
-}
+.dark {
+  color-scheme: dark;
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --ds-background: #FFFDF7 !important;
-    --ds-foreground: #2C2C2C !important;
-    --ds-surface: #F0F4F8 !important;
-    --ds-secondary-text: #6B7280 !important;
-    --ds-border: #E4E9EF !important;
-    --ds-border-strong: #D1D9E0 !important;
-    --ds-pink: #F5BCDD !important;
-    --ds-pink-hover: #EFABD0 !important;
-    --ds-purple: #DFD9F9 !important;
-    --ds-green: #B6C682 !important;
-    --ds-blue: #B9CBEC !important;
-    --ds-yellow: #F5D96E !important;
-    --ds-accent: #9B89C7 !important;
-    --ds-accent-hover: #8574B5 !important;
-    --ds-accent-muted: #DFD9F9 !important;
-    --ds-success: #7A8F4E !important;
-    --ds-success-muted: #B6C682 !important;
-    --ds-danger: #D97070 !important;
-    --ds-danger-muted: #FCE8E8 !important;
-    --ds-streak: #C4A824 !important;
-    --ds-overlay: rgb(44 44 44 / 0.4) !important;
-    --ds-on-accent: #FFFFFF !important;
-  }
+  --ds-background: #141418;
+  --ds-foreground: #F4F4F5;
+  --ds-surface: #1F1F26;
+  --ds-secondary-text: #A1A1AA;
+  --ds-border: #2E2E38;
+  --ds-border-strong: #3F3F4A;
+
+  --ds-pink: #D896B8;
+  --ds-pink-hover: #C985A9;
+  --ds-purple: #3D3555;
+  --ds-green: #3D4530;
+  --ds-blue: #2E3A4F;
+  --ds-yellow: #4A4228;
+
+  --ds-accent: #B8A8E0;
+  --ds-accent-hover: #A896D4;
+  --ds-accent-muted: #2A2438;
+  --ds-success: #9CB072;
+  --ds-success-muted: #2A3320;
+  --ds-danger: #E08A8A;
+  --ds-danger-muted: #3A2222;
+  --ds-streak: #E5C04A;
+
+  --ds-overlay: rgb(0 0 0 / 0.65);
+  --ds-on-accent: #FFFFFF;
+
+  --ds-shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.25);
+  --ds-shadow-md: 0 4px 12px -2px rgb(0 0 0 / 0.35);
+  --ds-shadow-lg: 0 12px 24px -4px rgb(0 0 0 / 0.4);
+  --ds-shadow-xl: 0 20px 40px -8px rgb(0 0 0 / 0.45);
+  --ds-shadow-pink: 0 8px 20px -4px rgb(216 150 184 / 0.25);
+  --ds-shadow-accent: 0 8px 20px -4px rgb(184 168 224 / 0.2);
 }
 
 @layer base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import localFont from "next/font/local";
 import { DM_Sans } from "next/font/google";
 import "./globals.css";
@@ -26,6 +27,8 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
 };
 
+const themeInitScript = `(function(){try{var t=localStorage.getItem('habit-tracker-theme');if(t==='dark'||(!t&&window.matchMedia('(prefers-color-scheme: dark)').matches)){document.documentElement.classList.add('dark')}}catch(e){}})();`;
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -35,7 +38,13 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${acorn.variable} ${dmSans.variable} h-full antialiased`}
+      suppressHydrationWarning
     >
+      <head>
+        <Script id="theme-init" strategy="beforeInteractive">
+          {themeInitScript}
+        </Script>
+      </head>
       <body className="min-h-full flex flex-col bg-background text-foreground font-sans">
         <ServiceWorkerRegister />
         {children}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,11 +1,15 @@
 import LoginForm from '@/components/auth/LoginForm';
+import AppHeader from '@/components/shared/AppHeader';
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4 sm:p-8">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--color-purple),transparent_40%)] opacity-60 pointer-events-none" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,var(--color-pink),transparent_40%)] opacity-50 pointer-events-none" />
-      <LoginForm />
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader />
+      <div className="relative flex flex-1 items-center justify-center p-4 sm:p-8">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--color-purple),transparent_40%)] opacity-60 pointer-events-none" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,var(--color-pink),transparent_40%)] opacity-50 pointer-events-none" />
+        <LoginForm />
+      </div>
     </div>
   );
 }

--- a/app/signup/page.tsx
+++ b/app/signup/page.tsx
@@ -1,11 +1,15 @@
 import SignupForm from '@/components/auth/SignupForm';
+import AppHeader from '@/components/shared/AppHeader';
 
 export default function SignupPage() {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-4 sm:p-8">
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--color-blue),transparent_40%)] opacity-50 pointer-events-none" />
-      <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,var(--color-yellow),transparent_40%)] opacity-40 pointer-events-none" />
-      <SignupForm />
+    <div className="flex min-h-screen flex-col bg-background">
+      <AppHeader />
+      <div className="relative flex flex-1 items-center justify-center p-4 sm:p-8">
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_top_right,var(--color-blue),transparent_40%)] opacity-50 pointer-events-none" />
+        <div className="absolute inset-0 bg-[radial-gradient(circle_at_bottom_left,var(--color-yellow),transparent_40%)] opacity-40 pointer-events-none" />
+        <SignupForm />
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -1,4 +1,5 @@
 import Skeleton from '@/components/ui/Skeleton';
+import ThemeToggle from '@/components/shared/ThemeToggle';
 
 export default function DashboardSkeleton() {
   return (
@@ -8,7 +9,8 @@ export default function DashboardSkeleton() {
           <Skeleton className="h-9 w-40" />
           <Skeleton className="h-5 w-56" />
         </div>
-        <div className="flex gap-2 md:gap-4">
+        <div className="flex gap-2 md:gap-4 items-center">
+          <ThemeToggle />
           <Skeleton className="h-10 flex-1 md:w-36 md:flex-none" />
           <Skeleton className="h-10 w-24" />
         </div>

--- a/src/components/landing/LandingPage.tsx
+++ b/src/components/landing/LandingPage.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { getSession } from '@/lib/auth';
 import type { Session } from '@/types/auth';
+import ThemeToggle from '@/components/shared/ThemeToggle';
 
 const features = [
   {
@@ -53,12 +54,13 @@ export default function LandingPage() {
 
   return (
     <div data-testid="landing-page" className="min-h-screen flex flex-col">
-      <header className="border-b border-border-base bg-background/90 backdrop-blur-sm sticky top-0 z-10">
+      <header className="border-b border-border-base bg-background/90 backdrop-blur-sm sticky top-0 z-20">
         <div className="max-w-5xl mx-auto px-4 md:px-8 h-16 flex items-center justify-between">
           <Link href="/" className="font-display text-lg font-extrabold tracking-tight text-foreground">
             Habit Tracker
           </Link>
           <nav className="flex items-center gap-2 md:gap-3">
+            <ThemeToggle />
             {session ? (
               <Link
                 href="/dashboard"

--- a/src/components/shared/AppHeader.tsx
+++ b/src/components/shared/AppHeader.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import ThemeToggle from '@/components/shared/ThemeToggle';
+
+export default function AppHeader() {
+  return (
+    <header className="border-b border-border-base bg-background/90 backdrop-blur-sm sticky top-0 z-20">
+      <div className="max-w-5xl mx-auto px-4 md:px-8 h-16 flex items-center justify-between">
+        <Link href="/" className="font-display text-lg font-bold tracking-tight text-foreground">
+          Habit Tracker
+        </Link>
+        <ThemeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/components/shared/ThemeToggle.tsx
+++ b/src/components/shared/ThemeToggle.tsx
@@ -1,0 +1,76 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { applyTheme, getPreferredTheme, type Theme } from '@/lib/theme';
+
+function IconSun({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      width={20}
+      height={20}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <circle cx="12" cy="12" r="5" />
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
+
+function IconMoon({ className }: { className?: string }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      className={className}
+      width={20}
+      height={20}
+      fill="none"
+      viewBox="0 0 24 24"
+      stroke="currentColor"
+      strokeWidth={2}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden
+    >
+      <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" />
+    </svg>
+  );
+}
+
+type ThemeToggleProps = {
+  className?: string;
+};
+
+export default function ThemeToggle({ className = '' }: ThemeToggleProps) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    setTheme(document.documentElement.classList.contains('dark') ? 'dark' : 'light');
+  }, []);
+
+  const handleToggle = () => {
+    const next: Theme = theme === 'light' ? 'dark' : 'light';
+    applyTheme(next);
+    setTheme(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggle}
+      data-testid="theme-toggle"
+      aria-label={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+      title={theme === 'light' ? 'Dark mode' : 'Light mode'}
+      className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-border-strong bg-surface text-foreground shadow-sm hover:bg-background transition-colors ${className}`}
+    >
+      {theme === 'light' ? <IconMoon /> : <IconSun />}
+    </button>
+  );
+}

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,27 @@
+export const THEME_STORAGE_KEY = 'habit-tracker-theme';
+
+export type Theme = 'light' | 'dark';
+
+export function getStoredTheme(): Theme | null {
+  if (typeof window === 'undefined') return null;
+  const stored = localStorage.getItem(THEME_STORAGE_KEY);
+  return stored === 'light' || stored === 'dark' ? stored : null;
+}
+
+export function getPreferredTheme(): Theme {
+  if (typeof window === 'undefined') return 'light';
+  const stored = getStoredTheme();
+  if (stored) return stored;
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+export function applyTheme(theme: Theme) {
+  document.documentElement.classList.toggle('dark', theme === 'dark');
+  localStorage.setItem(THEME_STORAGE_KEY, theme);
+}
+
+export function toggleTheme(): Theme {
+  const next: Theme = document.documentElement.classList.contains('dark') ? 'light' : 'dark';
+  applyTheme(next);
+  return next;
+}


### PR DESCRIPTION
## Summary
- Add dark mode design tokens mapped to the existing semantic color system
- Add theme toggle (bottom-right) with localStorage persistence
- Respect system preference on first visit; prevent flash with beforeInteractive script
- Remove forced light-mode CSS overrides

## Part of
Week 1 design pass (PR 5)

## Test plan
- [x] `npm run build`
- [ ] Manual: toggle dark mode on `/`, `/dashboard`, `/login` — colors update
- [ ] Manual: refresh page — theme persists
- [ ] Manual: clear localStorage, set OS to dark — app starts dark