### PR TITLE
Add weekly stats summary and best streak tracking

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import DashboardSkeleton from '@/components/dashboard/DashboardSkeleton';
 import EmptyState from '@/components/dashboard/EmptyState';
 import TodayProgress from '@/components/dashboard/TodayProgress';
 import TodayHabitsList from '@/components/dashboard/TodayHabitsList';
+import WeeklyStatsSummary from '@/components/dashboard/WeeklyStatsSummary';
 import ThemeToggle from '@/components/shared/ThemeToggle';
 import Button from '@/components/ui/Button';
 import Card from '@/components/ui/Card';
@@ -110,6 +111,7 @@ export default function DashboardPage() {
         ) : (
           <>
             <TodayProgress habits={habits} />
+            <WeeklyStatsSummary habits={habits} />
             <TodayHabitsList
               habits={habits}
               onUpdate={() => session && loadHabits(session.userId)}

--- a/app/habits/[id]/page.tsx
+++ b/app/habits/[id]/page.tsx
@@ -6,9 +6,10 @@ import { useParams, useRouter } from 'next/navigation';
 import { getSession } from '@/lib/auth';
 import { getHabitById, toggleHabitCompletion, updateHabit } from '@/lib/habits';
 import { getHabitColorOption } from '@/lib/habitAppearance';
-import { calculateCurrentStreak } from '@/lib/streaks';
+import { calculateBestStreak, calculateCurrentStreak } from '@/lib/streaks';
 import { getLocalDateString } from '@/lib/today';
 import { HEATMAP_WEEKS, buildHeatmap, getHeatmapCompletionRate } from '@/lib/heatmap';
+import { getHabitWeeklyStats } from '@/lib/stats';
 import type { Habit } from '@/types/habit';
 import CompletionHeatmap from '@/components/habits/CompletionHeatmap';
 import ThemeToggle from '@/components/shared/ThemeToggle';
@@ -51,11 +52,14 @@ export default function HabitDetailPage() {
 
     const grid = buildHeatmap(habit.completions, habit.createdAt);
     const isCompletedToday = habit.completions.includes(today);
+    const weeklyStats = getHabitWeeklyStats(habit, today);
 
     return {
       currentStreak: calculateCurrentStreak(habit.completions, today),
+      bestStreak: calculateBestStreak(habit.completions),
       totalCompletions: habit.completions.length,
       recentCompletionRate: getHeatmapCompletionRate(grid),
+      weeklyCompletionRate: weeklyStats.percentage,
       isCompletedToday,
     };
   }, [habit, today]);
@@ -160,7 +164,7 @@ export default function HabitDetailPage() {
             </Button>
           </div>
 
-          <div className="mt-6 grid grid-cols-3 gap-3">
+          <div className="mt-6 grid grid-cols-2 md:grid-cols-3 gap-3">
             <div className="rounded-2xl bg-background border border-border-base p-4 text-center">
               <p className="text-2xl font-bold text-streak" data-testid="habit-detail-current-streak">
                 {stats.currentStreak}🔥
@@ -168,12 +172,24 @@ export default function HabitDetailPage() {
               <p className="text-xs uppercase tracking-wide text-secondary-text mt-1">Current streak</p>
             </div>
             <div className="rounded-2xl bg-background border border-border-base p-4 text-center">
+              <p className="text-2xl font-bold text-streak" data-testid="habit-detail-best-streak">
+                {stats.bestStreak}🔥
+              </p>
+              <p className="text-xs uppercase tracking-wide text-secondary-text mt-1">Best streak</p>
+            </div>
+            <div className="rounded-2xl bg-background border border-border-base p-4 text-center">
+              <p className="text-2xl font-bold text-accent" data-testid="habit-detail-weekly-rate">
+                {stats.weeklyCompletionRate}%
+              </p>
+              <p className="text-xs uppercase tracking-wide text-secondary-text mt-1">This week</p>
+            </div>
+            <div className="rounded-2xl bg-background border border-border-base p-4 text-center">
               <p className="text-2xl font-bold text-foreground" data-testid="habit-detail-total-completions">
                 {stats.totalCompletions}
               </p>
               <p className="text-xs uppercase tracking-wide text-secondary-text mt-1">Total check-ins</p>
             </div>
-            <div className="rounded-2xl bg-background border border-border-base p-4 text-center">
+            <div className="rounded-2xl bg-background border border-border-base p-4 text-center md:col-span-2">
               <p className="text-2xl font-bold text-accent" data-testid="habit-detail-recent-rate">
                 {stats.recentCompletionRate}%
               </p>

--- a/src/components/dashboard/DashboardSkeleton.tsx
+++ b/src/components/dashboard/DashboardSkeleton.tsx
@@ -28,6 +28,12 @@ export default function DashboardSkeleton() {
           </div>
         </section>
 
+        <section className="bg-surface rounded-2xl shadow-md p-6 mb-6">
+          <Skeleton className="h-6 w-24 mb-3" />
+          <Skeleton className="h-4 w-56 mb-4" />
+          <Skeleton className="h-2 w-full rounded-full" />
+        </section>
+
         <section>
           <Skeleton className="h-6 w-28 mb-3" />
           <div className="grid gap-4 md:grid-cols-2">

--- a/src/components/dashboard/WeeklyStatsSummary.tsx
+++ b/src/components/dashboard/WeeklyStatsSummary.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import Card from '@/components/ui/Card';
+import type { Habit } from '@/types/habit';
+import { formatWeekRange, getDashboardWeeklyStats } from '@/lib/stats';
+import { cn } from '@/lib/cn';
+
+type WeeklyStatsSummaryProps = {
+  habits: Habit[];
+};
+
+export default function WeeklyStatsSummary({ habits }: WeeklyStatsSummaryProps) {
+  const stats = getDashboardWeeklyStats(habits);
+  const weekLabel = formatWeekRange(stats.weekStart, stats.weekEnd);
+
+  return (
+    <Card padding="md" className="mb-6" data-testid="weekly-stats-summary">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-xs font-medium uppercase tracking-wide text-secondary-text">This week</p>
+          <h2 className="font-display text-xl font-bold text-foreground">{weekLabel}</h2>
+          <p className="mt-1 text-secondary-text" data-testid="weekly-stats-summary-text">
+            {stats.total === 0
+              ? 'No check-ins due yet this week'
+              : `${stats.completed} of ${stats.total} check-ins completed · ${stats.percentage}%`}
+          </p>
+        </div>
+
+        <div className="sm:w-40 text-right">
+          <p className="font-display text-3xl font-bold text-accent" data-testid="weekly-stats-percentage">
+            {stats.percentage}%
+          </p>
+          <p className="text-xs uppercase tracking-wide text-secondary-text">Weekly rate</p>
+        </div>
+      </div>
+
+      <div className="mt-4 h-2 rounded-full bg-border-base overflow-hidden">
+        <div
+          className={cn(
+            'h-full rounded-full transition-all duration-500',
+            stats.percentage === 100 ? 'bg-success' : 'bg-accent'
+          )}
+          style={{ width: `${stats.percentage}%` }}
+          role="progressbar"
+          aria-valuenow={stats.percentage}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-label={`${stats.percentage}% of this week's check-ins completed`}
+        />
+      </div>
+    </Card>
+  );
+}

--- a/src/lib/stats.ts
+++ b/src/lib/stats.ts
@@ -1,0 +1,101 @@
+import type { Habit } from '@/types/habit';
+import { parseLocalDate } from '@/lib/heatmap';
+import { getLocalDateString } from '@/lib/today';
+
+export type WeeklyStats = {
+  completed: number;
+  total: number;
+  percentage: number;
+  weekStart: string;
+  weekEnd: string;
+};
+
+export function getWeekStart(today = getLocalDateString()): string {
+  const date = parseLocalDate(today);
+  date.setDate(date.getDate() - date.getDay());
+  return getLocalDateString(date);
+}
+
+function getDatesInRange(start: string, end: string): string[] {
+  const dates: string[] = [];
+  const current = parseLocalDate(start);
+  const endDate = parseLocalDate(end);
+
+  while (current <= endDate) {
+    dates.push(getLocalDateString(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+export function getHabitWeeklyStats(habit: Habit, today = getLocalDateString()): WeeklyStats {
+  const weekStart = getWeekStart(today);
+  const dates = getDatesInRange(weekStart, today);
+  const createdDate = getLocalDateString(new Date(habit.createdAt));
+  const completionSet = new Set(habit.completions);
+
+  let total = 0;
+  let completed = 0;
+
+  for (const date of dates) {
+    if (date >= createdDate) {
+      total++;
+      if (completionSet.has(date)) {
+        completed++;
+      }
+    }
+  }
+
+  return {
+    completed,
+    total,
+    percentage: total === 0 ? 0 : Math.round((completed / total) * 100),
+    weekStart,
+    weekEnd: today,
+  };
+}
+
+export function getDashboardWeeklyStats(habits: Habit[], today = getLocalDateString()): WeeklyStats {
+  const weekStart = getWeekStart(today);
+
+  if (habits.length === 0) {
+    return {
+      completed: 0,
+      total: 0,
+      percentage: 0,
+      weekStart,
+      weekEnd: today,
+    };
+  }
+
+  let completed = 0;
+  let total = 0;
+
+  for (const habit of habits) {
+    const habitStats = getHabitWeeklyStats(habit, today);
+    completed += habitStats.completed;
+    total += habitStats.total;
+  }
+
+  return {
+    completed,
+    total,
+    percentage: total === 0 ? 0 : Math.round((completed / total) * 100),
+    weekStart,
+    weekEnd: today,
+  };
+}
+
+export function formatWeekRange(weekStart: string, weekEnd: string): string {
+  const startLabel = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(parseLocalDate(weekStart));
+  const endLabel = new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(parseLocalDate(weekEnd));
+
+  return `${startLabel} – ${endLabel}`;
+}

--- a/src/lib/streaks.ts
+++ b/src/lib/streaks.ts
@@ -1,8 +1,11 @@
+import { getLocalDateString } from './today';
+import { parseLocalDate } from './heatmap';
+
 export const calculateCurrentStreak = (
   completions: string[],
   todayOverride?: string
 ): number => {
-  const today = todayOverride || new Date().toISOString().split('T')[0];
+  const today = todayOverride || getLocalDateString();
   const completionSet = new Set(completions);
 
   if (!completionSet.has(today)) {
@@ -10,12 +13,35 @@ export const calculateCurrentStreak = (
   }
 
   let streak = 0;
-  const currentDate = new Date(today);
+  const currentDate = parseLocalDate(today);
 
-  while (completionSet.has(currentDate.toISOString().split('T')[0])) {
+  while (completionSet.has(getLocalDateString(currentDate))) {
     streak++;
     currentDate.setDate(currentDate.getDate() - 1);
   }
 
   return streak;
+};
+
+export const calculateBestStreak = (completions: string[]): number => {
+  const uniqueDates = [...new Set(completions)].sort();
+  if (uniqueDates.length === 0) return 0;
+  if (uniqueDates.length === 1) return 1;
+
+  let best = 1;
+  let current = 1;
+
+  for (let index = 1; index < uniqueDates.length; index++) {
+    const previous = parseLocalDate(uniqueDates[index - 1]);
+    previous.setDate(previous.getDate() + 1);
+
+    if (getLocalDateString(previous) === uniqueDates[index]) {
+      current++;
+      best = Math.max(best, current);
+    } else {
+      current = 1;
+    }
+  }
+
+  return best;
 };

--- a/tests/unit/stats.test.ts
+++ b/tests/unit/stats.test.ts
@@ -1,0 +1,86 @@
+import type { Habit } from '../../src/types/habit';
+import {
+  formatWeekRange,
+  getDashboardWeeklyStats,
+  getHabitWeeklyStats,
+  getWeekStart,
+} from '../../src/lib/stats';
+
+const makeHabit = (overrides: Partial<Habit> = {}): Habit => ({
+  id: 'habit-1',
+  userId: 'user-1',
+  name: 'Read',
+  description: '',
+  frequency: 'daily',
+  color: 'blue',
+  emoji: '📚',
+  createdAt: '2026-06-01T00:00:00.000Z',
+  completions: [],
+  ...overrides,
+});
+
+describe('getWeekStart', () => {
+  it('returns the Sunday before the given date', () => {
+    expect(getWeekStart('2026-06-20')).toBe('2026-06-14');
+  });
+});
+
+describe('getHabitWeeklyStats', () => {
+  it('counts only trackable days since the habit was created', () => {
+    const habit = makeHabit({
+      createdAt: '2026-06-18T00:00:00.000Z',
+      completions: ['2026-06-18', '2026-06-19', '2026-06-20'],
+    });
+
+    expect(getHabitWeeklyStats(habit, '2026-06-20')).toEqual({
+      completed: 3,
+      total: 3,
+      percentage: 100,
+      weekStart: '2026-06-14',
+      weekEnd: '2026-06-20',
+    });
+  });
+
+  it('returns zero when no days are due yet this week', () => {
+    const habit = makeHabit({
+      createdAt: '2026-06-21T00:00:00.000Z',
+    });
+
+    expect(getHabitWeeklyStats(habit, '2026-06-20')).toEqual({
+      completed: 0,
+      total: 0,
+      percentage: 0,
+      weekStart: '2026-06-14',
+      weekEnd: '2026-06-20',
+    });
+  });
+});
+
+describe('getDashboardWeeklyStats', () => {
+  it('aggregates weekly completion across all habits', () => {
+    const habits = [
+      makeHabit({
+        id: '1',
+        completions: ['2026-06-19', '2026-06-20'],
+      }),
+      makeHabit({
+        id: '2',
+        completions: ['2026-06-20'],
+      }),
+    ];
+
+    expect(getDashboardWeeklyStats(habits, '2026-06-20')).toEqual({
+      completed: 3,
+      total: 14,
+      percentage: 21,
+      weekStart: '2026-06-14',
+      weekEnd: '2026-06-20',
+    });
+  });
+});
+
+describe('formatWeekRange', () => {
+  it('returns a readable date range', () => {
+    expect(formatWeekRange('2026-06-14', '2026-06-20')).toMatch(/Jun/);
+  });
+});

--- a/tests/unit/streaks.test.ts
+++ b/tests/unit/streaks.test.ts
@@ -1,4 +1,4 @@
-import { calculateCurrentStreak } from '../../src/lib/streaks';
+import { calculateBestStreak, calculateCurrentStreak } from '../../src/lib/streaks';
 
 describe('calculateCurrentStreak', () => {
   it('returns 0 when completions is empty', () => {
@@ -22,5 +22,12 @@ describe('calculateCurrentStreak', () => {
   it('breaks the streak when a calendar day is missing', () => {
     const completions = ['2026-04-27', '2026-04-25', '2026-04-24'];
     expect(calculateCurrentStreak(completions, '2026-04-27')).toBe(1);
+  });
+});
+
+describe('calculateBestStreak', () => {
+  it('returns the longest historical streak', () => {
+    const completions = ['2026-04-20', '2026-04-21', '2026-04-22', '2026-04-24'];
+    expect(calculateBestStreak(completions)).toBe(3);
   });
 });


### PR DESCRIPTION
## Summary
- Add calculateBestStreak for longest consecutive completion run
- Add weekly stats helpers for habit and dashboard completion rates
- Dashboard shows this week's check-in progress with a progress bar
- Habit detail page shows best streak and this week's completion rate

## Test plan
- [ ] Dashboard shows weekly stats card when habits exist
- [ ] Weekly percentage updates after completing habits this week
- [ ] Habit detail shows best streak higher than current when applicable
- [ ] Run `npx vitest run tests/unit/streaks.test.ts tests/unit/stats.test.ts --no-coverage`