### PR TITLE
Add JSON export and import for habit backups

### DIFF
--- a/app/dashboard/settings/page.tsx
+++ b/app/dashboard/settings/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSession, logout } from '@/lib/auth';
+import type { Session } from '@/types/auth';
+import DashboardShell from '@/components/dashboard/DashboardShell';
+import DashboardSkeleton from '@/components/dashboard/DashboardSkeleton';
+import DataBackupPanel from '@/components/settings/DataBackupPanel';
+
+export default function SettingsPage() {
+  const [session, setSession] = useState<Session | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshKey, setRefreshKey] = useState(0);
+  const router = useRouter();
+
+  useEffect(() => {
+    const currentSession = getSession();
+    if (!currentSession) {
+      router.push('/login');
+      return;
+    }
+
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setSession(currentSession);
+    setLoading(false);
+  }, [router, refreshKey]);
+
+  if (loading) {
+    return (
+      <div data-testid="settings-page">
+        <DashboardSkeleton />
+      </div>
+    );
+  }
+
+  return (
+    <DashboardShell
+      session={session!}
+      title="Settings"
+      subtitle="Manage your account data and backups"
+      testId="settings-page"
+      onLogout={() => logout()}
+      onCreateHabit={() => router.push('/dashboard')}
+    >
+      <DataBackupPanel
+        userId={session!.userId}
+        onImported={() => setRefreshKey((value) => value + 1)}
+      />
+    </DashboardShell>
+  );
+}

--- a/src/components/dashboard/DashboardShell.tsx
+++ b/src/components/dashboard/DashboardShell.tsx
@@ -11,6 +11,7 @@ type DashboardShellProps = {
   subtitle: string;
   onLogout: () => void;
   onCreateHabit: () => void;
+  testId?: string;
   children: ReactNode;
 };
 
@@ -20,12 +21,13 @@ export default function DashboardShell({
   subtitle,
   onLogout,
   onCreateHabit,
+  testId = 'dashboard-page',
   children,
 }: DashboardShellProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
 
   return (
-    <div className="min-h-screen bg-background flex" data-testid="dashboard-page">
+    <div className="min-h-screen bg-background flex" data-testid={testId}>
       <DashboardSidebar
         session={session}
         mobileOpen={mobileOpen}

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Link from 'next/link';
+import { usePathname } from 'next/navigation';
 import type { Session } from '@/types/auth';
-import { IconLayoutGrid, IconTrending, IconX } from '@/components/ui/Icon';
+import { IconLayoutGrid, IconSettings, IconTrending, IconX } from '@/components/ui/Icon';
 import Button from '@/components/ui/Button';
 import { cn } from '@/lib/cn';
 
@@ -18,13 +19,19 @@ const navItems = [
     href: '/dashboard',
     label: 'Overview',
     icon: IconLayoutGrid,
-    active: true,
+    isActive: (pathname: string) => pathname === '/dashboard',
   },
   {
     href: '/dashboard#weekly-stats',
     label: 'Weekly stats',
     icon: IconTrending,
-    active: false,
+    isActive: () => false,
+  },
+  {
+    href: '/dashboard/settings',
+    label: 'Data & backup',
+    icon: IconSettings,
+    isActive: (pathname: string) => pathname.startsWith('/dashboard/settings'),
   },
 ];
 
@@ -38,6 +45,8 @@ export default function DashboardSidebar({
   onClose,
   onLogout,
 }: DashboardSidebarProps) {
+  const pathname = usePathname();
+
   const sidebarContent = (
     <>
       <div className="px-5 py-6 border-b border-border-base">
@@ -59,15 +68,17 @@ export default function DashboardSidebar({
       <nav className="flex-1 px-3 py-4 space-y-1" aria-label="Dashboard navigation">
         {navItems.map((item) => {
           const Icon = item.icon;
+          const active = item.isActive(pathname);
 
           return (
             <Link
               key={item.href}
               href={item.href}
               onClick={onClose}
+              data-testid={item.href === '/dashboard/settings' ? 'settings-nav-link' : undefined}
               className={cn(
                 'flex items-center gap-3 rounded-xl px-3 py-2.5 text-sm font-medium transition-colors',
-                item.active
+                active
                   ? 'bg-accent-muted/70 text-foreground shadow-sm'
                   : 'text-secondary-text hover:bg-background hover:text-foreground'
               )}

--- a/src/components/settings/DataBackupPanel.tsx
+++ b/src/components/settings/DataBackupPanel.tsx
@@ -1,0 +1,138 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { downloadBackup, importBackup, parseBackup } from '@/lib/backup';
+import Button from '@/components/ui/Button';
+import Card from '@/components/ui/Card';
+import Modal from '@/components/ui/Modal';
+
+type DataBackupPanelProps = {
+  userId: string;
+  onImported: () => void;
+};
+
+export default function DataBackupPanel({ userId, onImported }: DataBackupPanelProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [pendingImport, setPendingImport] = useState<{ raw: string; count: number } | null>(null);
+  const [message, setMessage] = useState<{ type: 'success' | 'error'; text: string } | null>(null);
+
+  const handleExport = () => {
+    downloadBackup(userId);
+    setMessage({ type: 'success', text: 'Backup downloaded successfully.' });
+  };
+
+  const handleFileChange = async (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    event.target.value = '';
+
+    if (!file) return;
+
+    try {
+      const raw = await file.text();
+      const parsed = parseBackup(raw);
+
+      if (!parsed.ok) {
+        setMessage({ type: 'error', text: parsed.error });
+        return;
+      }
+
+      setPendingImport({ raw, count: parsed.payload.habits.length });
+    } catch {
+      setMessage({ type: 'error', text: 'Could not read the selected file.' });
+    }
+  };
+
+  const handleConfirmImport = () => {
+    if (!pendingImport) return;
+
+    const result = importBackup(userId, pendingImport.raw);
+
+    if (!result.ok) {
+      setMessage({ type: 'error', text: result.error });
+      setPendingImport(null);
+      return;
+    }
+
+    setPendingImport(null);
+    setMessage({
+      type: 'success',
+      text: `Imported ${result.importedCount} habit${result.importedCount === 1 ? '' : 's'}.`,
+    });
+    onImported();
+  };
+
+  return (
+    <>
+      <Card padding="md" data-testid="data-backup-panel">
+        <h2 className="font-display text-xl font-bold text-foreground">Data & backup</h2>
+        <p className="mt-2 text-secondary-text leading-relaxed">
+          Export your habits to a JSON file before clearing browser data, or restore from a previous
+          backup. Import replaces your current habits for this account.
+        </p>
+
+        {message ? (
+          <p
+            data-testid="backup-message"
+            className={
+              message.type === 'success'
+                ? 'mt-4 rounded-xl bg-success-muted/50 px-4 py-3 text-sm text-success'
+                : 'mt-4 rounded-xl bg-danger-muted px-4 py-3 text-sm text-danger'
+            }
+          >
+            {message.text}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+          <Button
+            onClick={handleExport}
+            data-testid="export-backup-button"
+            className="sm:flex-1"
+          >
+            Export backup
+          </Button>
+          <Button
+            variant="secondary"
+            onClick={() => fileInputRef.current?.click()}
+            data-testid="import-backup-button"
+            className="sm:flex-1"
+          >
+            Import backup
+          </Button>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="application/json,.json"
+            className="hidden"
+            data-testid="import-backup-input"
+            onChange={handleFileChange}
+          />
+        </div>
+      </Card>
+
+      {pendingImport ? (
+        <Modal onClose={() => setPendingImport(null)}>
+          <Card padding="md" className="shadow-xl" data-testid="import-backup-modal">
+            <h3 className="font-display text-lg font-bold text-foreground">Replace current habits?</h3>
+            <p className="mt-2 text-secondary-text">
+              This will replace your current habits with {pendingImport.count} habit
+              {pendingImport.count === 1 ? '' : 's'} from the backup file.
+            </p>
+            <div className="mt-6 flex gap-3">
+              <Button variant="secondary" fullWidth onClick={() => setPendingImport(null)}>
+                Cancel
+              </Button>
+              <Button
+                fullWidth
+                onClick={handleConfirmImport}
+                data-testid="confirm-import-backup-button"
+              >
+                Import habits
+              </Button>
+            </div>
+          </Card>
+        </Modal>
+      ) : null}
+    </>
+  );
+}

--- a/src/components/ui/Icon.tsx
+++ b/src/components/ui/Icon.tsx
@@ -81,6 +81,15 @@ export function IconMenu({ size = 20, className, ...props }: IconProps) {
   );
 }
 
+export function IconSettings({ size = 20, className, ...props }: IconProps) {
+  return (
+    <svg {...defaults} width={size} height={size} className={className} {...props}>
+      <circle cx="12" cy="12" r="3" />
+      <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+    </svg>
+  );
+}
+
 export function IconX({ size = 20, className, ...props }: IconProps) {
   return (
     <svg {...defaults} width={size} height={size} className={className} {...props}>

--- a/src/lib/backup.ts
+++ b/src/lib/backup.ts
@@ -1,0 +1,103 @@
+import type { Habit } from '@/types/habit';
+import { normalizeHabit } from '@/lib/habitAppearance';
+import { getUserHabits, replaceUserHabits } from '@/lib/habits';
+import { getLocalDateString } from '@/lib/today';
+
+export const BACKUP_VERSION = 1;
+
+export type HabitBackupPayload = {
+  version: number;
+  exportedAt: string;
+  userId: string;
+  habits: Habit[];
+};
+
+export type ImportBackupResult =
+  | { ok: true; importedCount: number }
+  | { ok: false; error: string };
+
+export function createBackupPayload(userId: string): HabitBackupPayload {
+  return {
+    version: BACKUP_VERSION,
+    exportedAt: new Date().toISOString(),
+    userId,
+    habits: getUserHabits(userId),
+  };
+}
+
+export function serializeBackup(payload: HabitBackupPayload): string {
+  return JSON.stringify(payload, null, 2);
+}
+
+export function parseBackup(
+  raw: string
+): { ok: true; payload: HabitBackupPayload } | { ok: false; error: string } {
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { ok: false, error: 'Invalid JSON file.' };
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return { ok: false, error: 'Backup file is missing required data.' };
+  }
+
+  const record = parsed as Record<string, unknown>;
+
+  if (record.version !== BACKUP_VERSION) {
+    return { ok: false, error: 'Unsupported backup version.' };
+  }
+
+  if (typeof record.userId !== 'string' || !Array.isArray(record.habits)) {
+    return { ok: false, error: 'Backup file is missing required data.' };
+  }
+
+  const habits = record.habits.map((habit) =>
+    normalizeHabit({ ...(habit as Record<string, unknown>), userId: record.userId })
+  );
+
+  return {
+    ok: true,
+    payload: {
+      version: BACKUP_VERSION,
+      exportedAt: typeof record.exportedAt === 'string' ? record.exportedAt : new Date().toISOString(),
+      userId: record.userId,
+      habits,
+    },
+  };
+}
+
+export function importBackup(userId: string, raw: string): ImportBackupResult {
+  const parsed = parseBackup(raw);
+
+  if (!parsed.ok) {
+    return parsed;
+  }
+
+  const habits = parsed.payload.habits.map((habit) => ({
+    ...habit,
+    userId,
+  }));
+
+  replaceUserHabits(userId, habits);
+
+  return {
+    ok: true,
+    importedCount: habits.length,
+  };
+}
+
+export function downloadBackup(userId: string): void {
+  if (typeof window === 'undefined') return;
+
+  const payload = createBackupPayload(userId);
+  const blob = new Blob([serializeBackup(payload)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `habit-tracker-backup-${getLocalDateString()}.json`;
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/src/lib/habits.ts
+++ b/src/lib/habits.ts
@@ -12,6 +12,15 @@ export function getHabits(): Habit[] {
   return parsed.map((habit) => normalizeHabit(habit));
 }
 
+export function getUserHabits(userId: string): Habit[] {
+  return getHabits().filter((habit) => habit.userId === userId);
+}
+
+export function replaceUserHabits(userId: string, habits: Habit[]): void {
+  const otherHabits = getHabits().filter((habit) => habit.userId !== userId);
+  localStorage.setItem(HABITS_KEY, JSON.stringify([...otherHabits, ...habits]));
+}
+
 export function saveHabit(habit: Habit): void {
   const habits = getHabits();
   localStorage.setItem(HABITS_KEY, JSON.stringify([...habits, habit]));

--- a/tests/unit/backup.test.ts
+++ b/tests/unit/backup.test.ts
@@ -1,0 +1,122 @@
+import type { Habit } from '../../src/types/habit';
+import {
+  BACKUP_VERSION,
+  createBackupPayload,
+  importBackup,
+  parseBackup,
+  serializeBackup,
+} from '../../src/lib/backup';
+import { getUserHabits } from '../../src/lib/habits';
+
+const sampleHabit: Habit = {
+  id: 'habit-1',
+  userId: 'user-1',
+  name: 'Read',
+  description: '10 minutes',
+  frequency: 'daily',
+  color: 'blue',
+  emoji: '📚',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  completions: ['2026-06-20'],
+};
+
+describe('createBackupPayload', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('includes only the current user habits', () => {
+    localStorage.setItem(
+      'habit-tracker-habits',
+      JSON.stringify([
+        sampleHabit,
+        { ...sampleHabit, id: 'habit-2', userId: 'other-user' },
+      ])
+    );
+
+    const payload = createBackupPayload('user-1');
+
+    expect(payload.version).toBe(BACKUP_VERSION);
+    expect(payload.userId).toBe('user-1');
+    expect(payload.habits).toHaveLength(1);
+    expect(payload.habits[0].id).toBe('habit-1');
+  });
+});
+
+describe('parseBackup', () => {
+  it('rejects invalid JSON', () => {
+    expect(parseBackup('{not json')).toEqual({
+      ok: false,
+      error: 'Invalid JSON file.',
+    });
+  });
+
+  it('rejects unsupported backup versions', () => {
+    expect(
+      parseBackup(JSON.stringify({ version: 99, userId: 'user-1', habits: [] }))
+    ).toEqual({
+      ok: false,
+      error: 'Unsupported backup version.',
+    });
+  });
+
+  it('parses a valid backup file', () => {
+    const raw = serializeBackup({
+      version: BACKUP_VERSION,
+      exportedAt: '2026-06-20T00:00:00.000Z',
+      userId: 'user-1',
+      habits: [sampleHabit],
+    });
+
+    const result = parseBackup(raw);
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.payload.habits[0].name).toBe('Read');
+      expect(result.payload.habits[0].color).toBe('blue');
+    }
+  });
+});
+
+describe('importBackup', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('replaces the current user habits with imported data', () => {
+    localStorage.setItem(
+      'habit-tracker-habits',
+      JSON.stringify([{ ...sampleHabit, id: 'old-habit', name: 'Old Habit' }])
+    );
+
+    const raw = serializeBackup({
+      version: BACKUP_VERSION,
+      exportedAt: '2026-06-20T00:00:00.000Z',
+      userId: 'user-1',
+      habits: [sampleHabit],
+    });
+
+    const result = importBackup('user-1', raw);
+
+    expect(result).toEqual({ ok: true, importedCount: 1 });
+    expect(getUserHabits('user-1')).toEqual([sampleHabit]);
+  });
+
+  it('does not overwrite another user habits', () => {
+    localStorage.setItem(
+      'habit-tracker-habits',
+      JSON.stringify([{ ...sampleHabit, id: 'other-habit', userId: 'other-user' }])
+    );
+
+    const raw = serializeBackup({
+      version: BACKUP_VERSION,
+      exportedAt: '2026-06-20T00:00:00.000Z',
+      userId: 'user-1',
+      habits: [sampleHabit],
+    });
+
+    importBackup('user-1', raw);
+
+    expect(getUserHabits('other-user')).toHaveLength(1);
+    expect(getUserHabits('user-1')).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
- Add backup helpers to export/import versioned JSON files
- New /dashboard/settings page with export and import UI
- Import confirms before replacing current user habits
- Sidebar link to Data & backup settings

## Test plan
- [ ] Export downloads a JSON file with your habits
- [ ] Import restores habits after confirmation
- [ ] Invalid file shows an error message
- [ ] Other users' habits are not affected by import
- [ ] Run `npx vitest run tests/unit/backup.test.ts --no-coverage`